### PR TITLE
Fix filter with dot function for regex

### DIFF
--- a/react-project/src/components/Navigator.jsx
+++ b/react-project/src/components/Navigator.jsx
@@ -28,11 +28,11 @@ function Navigator(props) {
   const handleDotFilterSwitch = (event) => {
     setIsDotFilterApplied(!isDotFilterApplied);
 
-    // if (event.target.checked) {
-    //   dispatch(addExclusionFilenamePrefixesFilter(["."]));
-    // } else if (!event.target.checked) {
-    //   dispatch(removeExclusionFilenamePrefixesFilter(["."]));
-    // }
+    if (event.target.checked) {
+      dispatch(addFilter(CONFIG.commonFilterExpressions.startingWithDot));
+    } else if (!event.target.checked) {
+      dispatch(removeFilter(CONFIG.commonFilterExpressions.startingWithDot));
+    }
   };
 
   const handleBusFactorRecalculationSwitch = (event) => {

--- a/react-project/src/config.js
+++ b/react-project/src/config.js
@@ -81,6 +81,9 @@ export const CONFIG = {
       width: "100%",
     },
   },
+  commonFilterExpressions: {
+    startingWithDot: ["^\\..*"],
+  },
   filters: {
     general: {
       extensions: [".md", ".1"],


### PR DESCRIPTION
This pull request contains a fix for the 'filter elements starting with dot' feature which stopped working after switching to regex for the filtering feature 