### PR TITLE
make filter exclusive instead of inclusive

### DIFF
--- a/react-project/src/config.js
+++ b/react-project/src/config.js
@@ -82,7 +82,7 @@ export const CONFIG = {
     },
   },
   commonFilterExpressions: {
-    startingWithDot: ["^\\..*"],
+    startingWithDot: ["^[^\\.].*"],
   },
   filters: {
     general: {


### PR DESCRIPTION
The previous fix implemented the filter in an inclusive manner, meaning that all files starting with a dot character were shown in the treemap, and all others were included. Now this has been fixed by making this specific filter inclusive, so that when this filter is applied, only those files and folders whose name DO NOT start with a dot character are shown in the treemap
