### PR TITLE
Proposal: move in, out, sort settings to corner of TreeMap

### DIFF
--- a/react-project/src/components/Navigator.jsx
+++ b/react-project/src/components/Navigator.jsx
@@ -131,7 +131,7 @@ function Navigator(props) {
                 ))}
               </ol>
             </nav>
-            <div className="d-flex mt-1">
+            <center>
               <ButtonSet>
                 <Button
                   onClick={() =>
@@ -149,7 +149,7 @@ function Navigator(props) {
                   <Icon glyph={archiveIcon} /> Home
                 </Button>
               </ButtonSet>
-            </div>
+            </center>
           </div>
         </Content>
       </Island>

--- a/react-project/src/components/Navigator.jsx
+++ b/react-project/src/components/Navigator.jsx
@@ -28,25 +28,17 @@ import ButtonSet from "@jetbrains/ring-ui/dist/button-set/button-set";
 import Button from "@jetbrains/ring-ui/dist/button/button";
 import arrowUpIcon from "@jetbrains/icons/arrow-up";
 import archiveIcon from "@jetbrains/icons/archive";
-import search from "@jetbrains/icons/search";
-import searchError from "@jetbrains/icons/search-error";
 import Icon from "@jetbrains/ring-ui/dist/icon/icon";
 import Island from "@jetbrains/ring-ui/dist/island/island";
 import Header from "@jetbrains/ring-ui/dist/island/header";
 import Content from "@jetbrains/ring-ui/dist/island/content";
-import updateIcon from "@jetbrains/icons/update";
-import Select from "@jetbrains/ring-ui/dist/select/select";
 import Toggle, { Size } from "@jetbrains/ring-ui/dist/toggle/toggle";
 import Text from "@jetbrains/ring-ui/dist/text/text";
-import { resetZoom } from "../d3/zoom";
-import { binary, layoutAlgorithmsMap, squarify } from "../d3/tiling";
-import { sortingOrderMap } from "../d3/sort";
 
 function Navigator(props) {
   const dispatch = props.dispatch;
   const currentPath = props.path;
   const folderFilter = props.currentFolderFilter;
-  const reduxTreemapLayoutFunctions = props.reduxTreemapLayoutFunctions;
   const setPathFunc = props.setPathFunc;
   const simulationData = props.simulationData;
   const simulationPath = props.simulationPath;
@@ -55,11 +47,7 @@ function Navigator(props) {
   const sortingOrder = props.sortingOrder;
   const statsData = props.statsData;
   const tilingFunction = props.tilingFunction;
-  const zoom = props.zoom;
 
-  const filterTemplates = CONFIG.filters;
-  const [isDotFilterApplied, setIsDotFilterApplied] = useState(false);
-  const [currentTemplate, setCurrentTemplate] = useState();
   const { t, i18n } = useTranslation();
 
   const currentExtensionsList = useMemo(() => {
@@ -93,27 +81,9 @@ function Navigator(props) {
     }
   };
 
-  const handleLayoutAlgorithm = (e) => {
-    dispatch(reduxTreemapLayoutFunctions.setTilingFunction(e.label));
-  };
-  const handleSortingKey = (e) => {
-    dispatch(reduxTreemapLayoutFunctions.setSortingKey(e.key));
-  };
-  const handleSortingOrder = (e) => {
-    console.log(e.label);
-    dispatch(reduxTreemapLayoutFunctions.setSortingOrder(e.label));
-  };
   const handleFolderFilterToggle = (e) => {
     console.log(e.target.checked);
     dispatch(toggleFolderFilter());
-  };
-
-  const zoomIn = () => {
-    d3.select("svg g g").transition().call(zoom.scaleBy, 2);
-  };
-
-  const zoomOut = () => {
-    d3.select("svg g g").transition().call(zoom.scaleBy, 0.5);
   };
 
   const pathIsland = () => {
@@ -179,68 +149,6 @@ function Navigator(props) {
                   <Icon glyph={archiveIcon} /> Home
                 </Button>
               </ButtonSet>
-            </div>
-            <div className="d-flex mt-1">
-              <ButtonSet>
-                <Button
-                  danger
-                  onClick={() => resetZoom(zoom)}>
-                  <Icon glyph={search} /> Reset
-                </Button>
-                <Button onClick={() => zoomIn()}>
-                  <Icon glyph={search} /> In
-                </Button>
-                <Button onClick={() => zoomOut()}>
-                  <Icon glyph={searchError} /> Out
-                </Button>
-              </ButtonSet>
-            </div>
-            <div className="d-flex mt-1">
-              <Select
-                inputPlaceholder="Layout Algorithm"
-                onChange={handleLayoutAlgorithm}
-                data={Object.keys(layoutAlgorithmsMap).map((element, index) => {
-                  return {
-                    label: element,
-                    key: index,
-                  };
-                })}
-                selectedLabel="Layout Algorithm"
-                label="Select..."></Select>
-            </div>
-            <div className="d-flex mt-1">
-              <Select
-                inputPlaceholder="Sorting Key"
-                onChange={handleSortingKey}
-                data={[
-                  {
-                    label: "bus factor",
-                    key: "busFactor",
-                  },
-                  {
-                    label: "name",
-                    key: "name",
-                  },
-                  {
-                    label: "size",
-                    key: "size",
-                  },
-                ]}
-                selectedLabel="Sorting Key"
-                label="Select..."></Select>
-            </div>
-            <div className="d-flex mt-1">
-              <Select
-                inputPlaceholder="Sorting Order"
-                onChange={handleSortingOrder}
-                data={Object.keys(sortingOrderMap).map((element, index) => {
-                  return {
-                    label: element,
-                    key: index,
-                  };
-                })}
-                selectedLabel="Sorting Order"
-                label="Select..."></Select>
             </div>
           </div>
         </Content>

--- a/react-project/src/components/Visualization.jsx
+++ b/react-project/src/components/Visualization.jsx
@@ -1,6 +1,6 @@
 /** @format */
 
-import React, {useCallback, useDeferredValue, useLayoutEffect, useState,} from "react";
+import React, {useCallback, useDeferredValue, useLayoutEffect,} from "react";
 import {batch, useDispatch, useSelector} from "react-redux";
 import {useSearchParams} from "react-router-dom";
 import {CONFIG} from "../config";
@@ -27,7 +27,7 @@ import {
   setSortingOrder,
   setTilingFunction,
   simulationVisualizationData,
-  simulationVisualizationPath, toggleFolderFilter,
+  simulationVisualizationPath,
 } from "../reducers/treemapSlice";
 
 import {payloadGenerator} from "../utils/reduxActionPayloadCreator.tsx";
@@ -37,8 +37,7 @@ import TreeMap from "./TreeMap";
 import RightColumn from "./RightColumn";
 import {Col, Grid, Row} from "@jetbrains/ring-ui/dist/grid/grid";
 import {createZoom} from "../d3/zoom";
-import Island from "@jetbrains/ring-ui/dist/island/island";
-import {Content} from "@jetbrains/ring-ui/dist/island/island";
+import Island, {Content} from "@jetbrains/ring-ui/dist/island/island";
 import search from "@jetbrains/icons/search";
 import searchError from "@jetbrains/icons/search-error";
 import settingsIcon from "@jetbrains/icons/settings";
@@ -307,30 +306,24 @@ function Visualization() {
                     <Content>
                       <div className="d-flex mt-1">
                         <Select
-                          inputPlaceholder="Layout Algorithm"
                           onChange={handleLayoutAlgorithm}
                           data={layoutAlgorithmSelectData}
                           selected={findSelectItem(layoutAlgorithmSelectData, currentTilingFunction)}
-                          selectedLabel="Layout Algorithm"
-                          label="Select..."></Select>
+                          selectedLabel="Layout Algorithm"></Select>
                       </div>
                       <div className="d-flex mt-1">
                         <Select
-                          inputPlaceholder="Sorting Key"
                           onChange={handleSortingKey}
                           data={sortKeySelectData}
                           selected={findSelectItem(sortKeySelectData, currentSortingKey)}
-                          selectedLabel="Sorting Key"
-                          label="Select..."></Select>
+                          selectedLabel="Sorting Key"></Select>
                       </div>
                       <div className="d-flex mt-1">
                         <Select
-                          inputPlaceholder="Sorting Order"
                           onChange={handleSortingOrder}
                           data={sortingOrderSelectData}
                           selected={findSelectItem(sortingOrderSelectData, currentSortingOrder)}
-                          selectedLabel="Sorting Order"
-                          label="Select..."></Select>
+                          selectedLabel="Sorting Order"></Select>
                       </div>
                     </Content>
                   </Island>

--- a/react-project/src/components/Visualization.jsx
+++ b/react-project/src/components/Visualization.jsx
@@ -36,7 +36,7 @@ import Navigator from "./Navigator";
 import TreeMap from "./TreeMap";
 import RightColumn from "./RightColumn";
 import {Col, Grid, Row} from "@jetbrains/ring-ui/dist/grid/grid";
-import {createZoom, resetZoom} from "../d3/zoom";
+import {createZoom} from "../d3/zoom";
 import Island from "@jetbrains/ring-ui/dist/island/island";
 import {Content} from "@jetbrains/ring-ui/dist/island/island";
 import search from "@jetbrains/icons/search";
@@ -274,13 +274,6 @@ function Visualization() {
                 <Popup>
                   <Island>
                     <Content>
-                      <Button
-                        text
-                        danger
-                        onClick={() => resetZoom(mainTreemapZoom)}
-                        title={"Reset Zoom"}>
-                        reset
-                      </Button>
                       <div className="d-flex mt-1">
                         <Select
                           inputPlaceholder="Layout Algorithm"

--- a/react-project/src/components/Visualization.jsx
+++ b/react-project/src/components/Visualization.jsx
@@ -280,11 +280,11 @@ function Visualization() {
               top: 10,
               right: 25,
               display: "flex",
-              "flex-direction": "row",
+              flexDirection: "row",
               border: "1px solid black",
-              "border-radius": "10px",
-              "background-color": "white",
-              "box-shadow": "0 1px 2px black"
+              borderRadius: "10px",
+              backgroundColor: "white",
+              boxShadow: "0 1px 2px black"
             }}>
               <Button
                 onClick={() => zoomIn()}

--- a/react-project/src/components/Visualization.jsx
+++ b/react-project/src/components/Visualization.jsx
@@ -300,7 +300,6 @@ function Visualization() {
                 activeClassName="rotated"
                 anchor={<Button title="Details" icon={settingsIcon}/>}
               >
-                {/*TODO: add default value, reset*/}
                 <Popup>
                   <Island>
                     <Content>

--- a/react-project/src/components/Visualization.jsx
+++ b/react-project/src/components/Visualization.jsx
@@ -179,15 +179,46 @@ function Visualization() {
   };
 
   const handleLayoutAlgorithm = (e) => {
-    dispatch(reduxTreemapLayoutFunctions.setTilingFunction(e.label));
+    dispatch(reduxTreemapLayoutFunctions.setTilingFunction(e.key));
   };
   const handleSortingKey = (e) => {
     dispatch(reduxTreemapLayoutFunctions.setSortingKey(e.key));
   };
   const handleSortingOrder = (e) => {
     console.log(e.label);
-    dispatch(reduxTreemapLayoutFunctions.setSortingOrder(e.label));
+    dispatch(reduxTreemapLayoutFunctions.setSortingOrder(e.key));
   };
+
+  const layoutAlgorithmSelectData = Object.keys(layoutAlgorithmsMap).map((element, index) => {
+    return {
+      label: element,
+      key: element,
+    };
+  })
+
+  const sortKeySelectData = [
+    {
+      label: "bus factor",
+      key: "busFactor",
+    },
+    {
+      label: "name",
+      key: "name",
+    },
+    {
+      label: "size",
+      key: "size",
+    },
+  ]
+
+  const sortingOrderSelectData = Object.keys(sortingOrderMap).map((element, index) => {
+    return {
+      label: element,
+      key: element,
+    };
+  })
+
+  const findSelectItem = (items, currentValue) => items.find(e => e.key === currentValue)
 
   return (
     <Grid>
@@ -246,8 +277,8 @@ function Visualization() {
 
             <div style={{
               position: "absolute",
-              top: 5,
-              right: 20,
+              top: 10,
+              right: 25,
               display: "flex",
               "flex-direction": "row",
               border: "1px solid black",
@@ -278,12 +309,8 @@ function Visualization() {
                         <Select
                           inputPlaceholder="Layout Algorithm"
                           onChange={handleLayoutAlgorithm}
-                          data={Object.keys(layoutAlgorithmsMap).map((element, index) => {
-                            return {
-                              label: element,
-                              key: index,
-                            };
-                          })}
+                          data={layoutAlgorithmSelectData}
+                          selected={findSelectItem(layoutAlgorithmSelectData, currentTilingFunction)}
                           selectedLabel="Layout Algorithm"
                           label="Select..."></Select>
                       </div>
@@ -291,20 +318,8 @@ function Visualization() {
                         <Select
                           inputPlaceholder="Sorting Key"
                           onChange={handleSortingKey}
-                          data={[
-                            {
-                              label: "bus factor",
-                              key: "busFactor",
-                            },
-                            {
-                              label: "name",
-                              key: "name",
-                            },
-                            {
-                              label: "size",
-                              key: "size",
-                            },
-                          ]}
+                          data={sortKeySelectData}
+                          selected={findSelectItem(sortKeySelectData, currentSortingKey)}
                           selectedLabel="Sorting Key"
                           label="Select..."></Select>
                       </div>
@@ -312,12 +327,8 @@ function Visualization() {
                         <Select
                           inputPlaceholder="Sorting Order"
                           onChange={handleSortingOrder}
-                          data={Object.keys(sortingOrderMap).map((element, index) => {
-                            return {
-                              label: element,
-                              key: index,
-                            };
-                          })}
+                          data={sortingOrderSelectData}
+                          selected={findSelectItem(sortingOrderSelectData, currentSortingOrder)}
                           selectedLabel="Sorting Order"
                           label="Select..."></Select>
                       </div>

--- a/react-project/src/components/Visualization.jsx
+++ b/react-project/src/components/Visualization.jsx
@@ -244,92 +244,96 @@ function Visualization() {
               type="main"
               zoom={mainTreemapZoom}></TreeMap>
 
-            <Island style={{
+            <div style={{
               position: "absolute",
               top: 5,
-              right: 20
+              right: 20,
+              display: "flex",
+              "flex-direction": "row",
+              border: "1px solid black",
+              "border-radius": "10px",
+              "background-color": "white",
+              "box-shadow": "0 1px 2px black"
             }}>
-              <Content>
-                <Button
-                  onClick={() => zoomIn()}
-                  icon={search}
-                  title={"Zoom In"}
-                />
-                <Button
-                  onClick={() => zoomOut()}
-                  icon={searchError}
-                  title={"Zoom Out"}
-                />
-                  <Dropdown
-                    className="chevron"
-                    activeClassName="rotated"
-                    anchor={<Button title="Details" icon={settingsIcon}/>}
-                  >
-                    {/*TODO: add default value, reset*/}
-                    <Popup>
-                      <Island>
-                        <Content>
-                          <Button
-                            text
-                            danger
-                            onClick={() => resetZoom(mainTreemapZoom)}
-                            title={"Reset Zoom"}>
-                            reset
-                          </Button>
-                          <div className="d-flex mt-1">
-                            <Select
-                              inputPlaceholder="Layout Algorithm"
-                              onChange={handleLayoutAlgorithm}
-                              data={Object.keys(layoutAlgorithmsMap).map((element, index) => {
-                                return {
-                                  label: element,
-                                  key: index,
-                                };
-                              })}
-                              selectedLabel="Layout Algorithm"
-                              label="Select..."></Select>
-                          </div>
-                          <div className="d-flex mt-1">
-                            <Select
-                              inputPlaceholder="Sorting Key"
-                              onChange={handleSortingKey}
-                              data={[
-                                {
-                                  label: "bus factor",
-                                  key: "busFactor",
-                                },
-                                {
-                                  label: "name",
-                                  key: "name",
-                                },
-                                {
-                                  label: "size",
-                                  key: "size",
-                                },
-                              ]}
-                              selectedLabel="Sorting Key"
-                              label="Select..."></Select>
-                          </div>
-                          <div className="d-flex mt-1">
-                            <Select
-                              inputPlaceholder="Sorting Order"
-                              onChange={handleSortingOrder}
-                              data={Object.keys(sortingOrderMap).map((element, index) => {
-                                return {
-                                  label: element,
-                                  key: index,
-                                };
-                              })}
-                              selectedLabel="Sorting Order"
-                              label="Select..."></Select>
-                          </div>
-                        </Content>
-                      </Island>
+              <Button
+                onClick={() => zoomIn()}
+                icon={search}
+                title={"Zoom In"}
+              />
+              <Button
+                onClick={() => zoomOut()}
+                icon={searchError}
+                title={"Zoom Out"}
+              />
+              <Dropdown
+                className="chevron"
+                activeClassName="rotated"
+                anchor={<Button title="Details" icon={settingsIcon}/>}
+              >
+                {/*TODO: add default value, reset*/}
+                <Popup>
+                  <Island>
+                    <Content>
+                      <Button
+                        text
+                        danger
+                        onClick={() => resetZoom(mainTreemapZoom)}
+                        title={"Reset Zoom"}>
+                        reset
+                      </Button>
+                      <div className="d-flex mt-1">
+                        <Select
+                          inputPlaceholder="Layout Algorithm"
+                          onChange={handleLayoutAlgorithm}
+                          data={Object.keys(layoutAlgorithmsMap).map((element, index) => {
+                            return {
+                              label: element,
+                              key: index,
+                            };
+                          })}
+                          selectedLabel="Layout Algorithm"
+                          label="Select..."></Select>
+                      </div>
+                      <div className="d-flex mt-1">
+                        <Select
+                          inputPlaceholder="Sorting Key"
+                          onChange={handleSortingKey}
+                          data={[
+                            {
+                              label: "bus factor",
+                              key: "busFactor",
+                            },
+                            {
+                              label: "name",
+                              key: "name",
+                            },
+                            {
+                              label: "size",
+                              key: "size",
+                            },
+                          ]}
+                          selectedLabel="Sorting Key"
+                          label="Select..."></Select>
+                      </div>
+                      <div className="d-flex mt-1">
+                        <Select
+                          inputPlaceholder="Sorting Order"
+                          onChange={handleSortingOrder}
+                          data={Object.keys(sortingOrderMap).map((element, index) => {
+                            return {
+                              label: element,
+                              key: index,
+                            };
+                          })}
+                          selectedLabel="Sorting Order"
+                          label="Select..."></Select>
+                      </div>
+                    </Content>
+                  </Island>
 
-                    </Popup>
-                  </Dropdown>
-              </Content>
-            </Island>
+                </Popup>
+              </Dropdown>
+            </div>
           </center>
         </Col>
         <Col

--- a/react-project/src/components/Visualization.jsx
+++ b/react-project/src/components/Visualization.jsx
@@ -247,8 +247,7 @@ function Visualization() {
             <Island style={{
               position: "absolute",
               top: 5,
-              right: 20,
-              flex: 1
+              right: 20
             }}>
               <Content>
                 <Button


### PR DESCRIPTION
Hi! At the moment I need to fix overall placement:
* make `top`, `right` style values of island dependent on the size of treemap or distance between top of treemap and first line tiles
* ~~remove padding inside the island to prevent scroll bar appearance on smaller values of height or replace it with another component~~
* ~~add default values for sort selectors~~
* make icons more visible
* ~~remove or come up with a better idea with the reset button (currently it's inside dropdown)~~
