### PR TITLE
Replace json back to js file

### DIFF
--- a/react-project/src/index.js
+++ b/react-project/src/index.js
@@ -1,13 +1,13 @@
 /** @format */
 
-import React, { useEffect } from "react";
-import { createRoot } from "react-dom/client";
-import { Provider, useDispatch } from "react-redux";
+import React, {useEffect} from "react";
+import {createRoot} from "react-dom/client";
+import {Provider, useDispatch} from "react-redux";
 
-import { BrowserRouter } from "react-router-dom";
+import {BrowserRouter} from "react-router-dom";
 
 import Visualization from "./components/Visualization";
-import { store } from "./store";
+import {store} from "./store";
 import "./i18n";
 
 // Importing the Bootstrap CSS
@@ -15,8 +15,8 @@ import "bootstrap/dist/js/bootstrap.bundle";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap-icons/font/bootstrap-icons.css";
 import "@jetbrains/ring-ui/dist/style.css";
-import { setNewTree } from "./reducers/treemapSlice";
-import gitRepoDirData from "./data/busFactor.json";
+import {setNewTree} from "./reducers/treemapSlice";
+import {busFactorTree} from "./data/busFactor.js";
 
 const container = document.getElementById("appRoot");
 const root = createRoot(container);
@@ -24,20 +24,19 @@ const root = createRoot(container);
 
 function AppM() {
   const dispatch = useDispatch();
-  const tree = gitRepoDirData;
   // Similar to componentDidMount and componentDidUpdate:
   useEffect(() => {
-    dispatch(setNewTree(tree));
-  }, [dispatch, tree]);
+    dispatch(setNewTree(busFactorTree));
+  }, [dispatch]);
 
-  return <Visualization />;
+  return <Visualization/>;
 }
 
 root.render(
   // <React.StrictMode>
   <BrowserRouter>
     <Provider store={store}>
-      <AppM />
+      <AppM/>
     </Provider>
   </BrowserRouter>
   // </React.StrictMode>


### PR DESCRIPTION
For deployment, we need to move the json file to the `public` folder and use `fetch` to get data from it.There was no need to switch to json format, so lets rollback